### PR TITLE
Fixed JRS imageSelector when not in the last comic

### DIFF
--- a/supported_sites.json
+++ b/supported_sites.json
@@ -3,7 +3,7 @@
   "url":"http://www.maiuscentral.com/jrs/",
   "title":"Johnny, Roy y Steffy",
   "imageUrl":"http://www.maiuscentral.com/jrs/wp-content/uploads/2016/07/jrs329-small.png",
-  "imageSelector":"div#comic > img",
+  "imageSelector":"div[id^='comic'] img",
   "imageIndex":"0",
   "firstSelector":".comic-nav > a",
   "firstIndex":"0",


### PR DESCRIPTION
It uses different CSS selectors when using the previous and next buttons. This should fix it.