### PR TITLE
Fixed Sleepless Domain image selector

### DIFF
--- a/supported_sites.json
+++ b/supported_sites.json
@@ -6179,7 +6179,7 @@
   "url":"http://www.sleeplessdomain.com/",
   "title":"Sleepless Domain",
   "imageUrl":"http://www.sleeplessdomain.com/comics/1438655415-chaptercover.png",
-  "imageSelector":"div#cc-comic",
+  "imageSelector":"img#cc-comic",
   "imageIndex":"0",
   "firstSelector":"a.cc-first",
   "firstIndex":"0",

--- a/supported_sites.json
+++ b/supported_sites.json
@@ -6176,9 +6176,9 @@
   "nsfw":false
  },
  {
-  "url":"http://www.sleeplessdomain.com/",
+  "url":"https://www.sleeplessdomain.com/",
   "title":"Sleepless Domain",
-  "imageUrl":"http://www.sleeplessdomain.com/comics/1438655415-chaptercover.png",
+  "imageUrl":"https://www.sleeplessdomain.com/comics/1438655415-chaptercover.png",
   "imageSelector":"img#cc-comic",
   "imageIndex":"0",
   "firstSelector":"a.cc-first",


### PR DESCRIPTION
So sorry, accidentally put the wrong selector in the last commit. This one is accurate. Also changed the source to use https instead of http.