### PR TITLE
Added Drugs & Wires

### DIFF
--- a/supported_sites.json
+++ b/supported_sites.json
@@ -6340,5 +6340,24 @@
     "lastSelector": "#comic-nav > a:nth-child(4) > img",
     "lastIndex": "0",
     "nsfw": false
-  }
+  },
+  {
+    "url":"https://www.drugsandwires.fail/",
+    "title":"Drugs & Wires",
+    "imageUrl":"https://www.drugsandwires.fail/wp-content/uploads/2018/07/header.gif",
+    "imageSelector":"img.attachment-full",
+    "imageIndex":"0",
+    "firstSelector":".first-webcomic-link",
+    "firstIndex":"0",
+    "prevSelector":".previous-webcomic-link",
+    "prevIndex":"0",
+    "randomSelector":".random-webcomic-link",
+    "randomIndex":"0",
+    "nextSelector":".next-webcomic-link",
+    "nextIndex":"0",
+    "lastSelector":".last-webcomic-link",
+    "lastIndex":"0",
+    "donateUrl":"https://www.patreon.com/drugsandwires",
+    "nsfw":true
+}
 ]


### PR DESCRIPTION
Pretty sure it's correct, but do test! 

The "random" link is generated server-side - each page is served with a link to another comic (chosen at random) hardcoded into the href. I presume this is quite common, and PageFlip pulls a fresh link out of the DOM each time, in which case no problem :). If you tried to cache/memoize it, it'd always link to the same comic.

(Also not sure about NSFW; it includes swearing and drugs, and is set in a cyberpunk world, so I put true)