### PR TITLE
Updated Questionable Content as page format changed

### DIFF
--- a/supported_sites.json
+++ b/supported_sites.json
@@ -3014,7 +3014,7 @@
     "title": "Questionable Content",
     "imageUrl": "https://www.questionablecontent.net/comics/3252.png",
     "imageSelector": ".column>.row img",
-    "imageIndex": "0",
+    "imageIndex": "1",
     "firstSelector": "#comicnav a",
     "firstIndex": "0",
     "prevSelector": "#comicnav a",


### PR DESCRIPTION
Please verify if this fix works. Intended to find comic image, which used to be first image on page, but is now second image on page.